### PR TITLE
feat: add Q8_0 quantization support for TTS inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,11 @@ name = "q4_pipeline"
 harness = false
 required-features = ["wgpu"]
 
+[[bench]]
+name = "q8_ops"
+harness = false
+required-features = ["wgpu"]
+
 # WASM library target
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ cargo run --release --features "wgpu,cli,hub" --bin voxtral -- \
 cargo run --release --features "wgpu,cli,hub" --bin voxtral -- speak --list-voices
 ```
 
+#### Q8_0 (optional, near-lossless)
+
+Q8_0 sits between Q4 and BF16: ~4.5 GB on disk, audio quality much closer to BF16. There is no hosted Q8 GGUF — generate it locally from the BF16 weights:
+
+```bash
+# Quantize BF16 -> Q8_0 GGUF (~4.5 GB)
+uv run --with safetensors --with torch --with numpy scripts/quantize_tts_gguf.py \
+  models/voxtral-tts/ -o models/voxtral-tts-q8.gguf --quant-type q8_0
+
+# Synthesize with Q8
+cargo run --release --features "wgpu,cli,hub" --bin voxtral -- \
+  speak --text "Hello world" --voice casual_female --gguf models/voxtral-tts-q8.gguf
+```
+
 20 preset voices across 9 languages. The TTS pipeline runs backbone (Ministral 3B) autoregressive decoding, flow-matching acoustic prediction, and codec synthesis to produce 24 kHz audio.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -109,12 +109,15 @@ cargo run --release --features "wgpu,cli,hub" --bin voxtral -- \
 cargo run --release --features "wgpu,cli,hub" --bin voxtral -- speak --list-voices
 ```
 
-#### Q8_0 (optional, near-lossless)
+#### Q8_0 (optional, experimental)
 
-Q8_0 sits between Q4 and BF16: ~4.5 GB on disk, audio quality much closer to BF16. There is no hosted Q8 GGUF — generate it locally from the BF16 weights:
+The Q8_0 block layout suggests an approximately 4.5 GB GGUF on disk. This
+validation does not include a generated full-model Q8 file or listening-quality
+evaluation. There is no hosted Q8 GGUF; generate one locally from the BF16
+weights to evaluate it in your own environment:
 
 ```bash
-# Quantize BF16 -> Q8_0 GGUF (~4.5 GB)
+# Quantize BF16 -> Q8_0 GGUF (approximately 4.5 GB from the block layout)
 uv run --with safetensors --with torch --with numpy scripts/quantize_tts_gguf.py \
   models/voxtral-tts/ -o models/voxtral-tts-q8.gguf --quant-type q8_0
 

--- a/benches/q8_ops.rs
+++ b/benches/q8_ops.rs
@@ -1,0 +1,94 @@
+//! GPU Q8 kernel micro-benchmarks (no model weights needed).
+//!
+//! Benchmarks `q8_matmul` at real model shapes using synthetic Q8_0 data,
+//! mirroring `q4_ops.rs` so Q4_0 and Q8_0 throughput can be compared directly.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+
+use burn::backend::Wgpu;
+use burn::tensor::{Tensor, TensorData};
+
+use voxtral_mini_realtime::gguf::{q8_matmul, Q4Tensor};
+
+const Q8_BLOCK_SIZE: usize = 32;
+const Q8_BLOCK_BYTES: usize = 34;
+
+/// Quantize f32 data to Q8_0 format (test helper, mirrors src/gguf/tests.rs).
+fn quantize_f32_to_q8_0(data: &[f32]) -> Vec<u8> {
+    assert_eq!(data.len() % Q8_BLOCK_SIZE, 0);
+    let n_blocks = data.len() / Q8_BLOCK_SIZE;
+    let mut output = Vec::with_capacity(n_blocks * Q8_BLOCK_BYTES);
+
+    for block_idx in 0..n_blocks {
+        let block = &data[block_idx * Q8_BLOCK_SIZE..(block_idx + 1) * Q8_BLOCK_SIZE];
+        let amax = block.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        let d = amax / 127.0;
+        let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+
+        let d_f16 = half::f16::from_f32(d);
+        output.extend_from_slice(&d_f16.to_le_bytes());
+
+        for &v in block {
+            let q = (v * id).round().clamp(-127.0, 127.0) as i8;
+            output.push(q as u8);
+        }
+    }
+    output
+}
+
+/// Prepare a Q8 tensor from random-ish f32 data at the given shape [N, K].
+fn make_q8_weights(
+    n: usize,
+    k: usize,
+    device: &<Wgpu as burn::tensor::backend::Backend>::Device,
+) -> Q4Tensor {
+    let weight_data: Vec<f32> = (0..n * k)
+        .map(|i| ((i as f32) * 0.0007).cos() * 0.05)
+        .collect();
+    let q8_bytes = quantize_f32_to_q8_0(&weight_data);
+    Q4Tensor::from_q8_bytes(&q8_bytes, [n, k], device).expect("Failed to create Q8 tensor")
+}
+
+fn bench_q8_matmul(c: &mut Criterion) {
+    let device: <Wgpu as burn::tensor::backend::Backend>::Device = Default::default();
+
+    // (batch, seq, K, N, description) — same shapes as q4_ops.rs
+    let shapes: &[(usize, usize, usize, usize, &str)] = &[
+        (1, 1, 3072, 3072, "dec_attn_wq_1tok"),
+        (1, 38, 3072, 3072, "dec_attn_wq_prefill"),
+        (1, 1, 3072, 9216, "dec_ffn_w1_1tok"),
+        (1, 38, 3072, 9216, "dec_ffn_w1_prefill"),
+        (1, 1, 1280, 5120, "enc_ffn_w1"),
+        (1, 100, 1280, 1280, "enc_attn_wq_100pos"),
+    ];
+
+    let mut group = c.benchmark_group("q8_matmul");
+
+    for &(batch, seq, k, n, desc) in shapes {
+        let q8_weights = make_q8_weights(n, k, &device);
+        let act_data: Vec<f32> = (0..batch * seq * k)
+            .map(|i| ((i as f32) * 0.001).sin() * 0.1)
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{desc}_[{batch},{seq},{k}]x[{n},{k}]")),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    let activations = Tensor::<Wgpu, 3>::from_data(
+                        TensorData::new(act_data.clone(), [batch, seq, k]),
+                        &device,
+                    );
+                    let output = q8_matmul(black_box(activations), &q8_weights);
+                    // Force GPU sync by reading output data
+                    output.to_data()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_q8_matmul);
+criterion_main!(benches);

--- a/scripts/quantize_tts_gguf.py
+++ b/scripts/quantize_tts_gguf.py
@@ -7,15 +7,20 @@
 #     "numpy",
 # ]
 # ///
-"""Quantize Voxtral 4B TTS weights from SafeTensors to GGUF v3 with Q4_0.
+"""Quantize Voxtral 4B TTS weights from SafeTensors to GGUF v3.
 
-Reads consolidated.safetensors, quantizes backbone + FM linear layers to Q4_0,
+Supports Q4_0 and Q8_0 quantization (selectable via --quant-type).
+
+Reads consolidated.safetensors, quantizes backbone + FM linear layers,
 keeps codec/norms/small tensors as F32, pre-fuses codec weight norms, and writes
 a valid GGUF v3 file consumable by the Rust reader in src/gguf/reader.rs.
 
 Usage:
     uv run --with safetensors --with torch --with numpy scripts/quantize_tts_gguf.py \\
-        models/voxtral-tts/ -o models/voxtral-tts-q4.gguf
+        models/voxtral-tts/ -o models/voxtral-tts-q8.gguf --quant-type q8_0
+
+    uv run --with safetensors --with torch --with numpy scripts/quantize_tts_gguf.py \\
+        models/voxtral-tts/ -o models/voxtral-tts-q4.gguf --quant-type q4_0
 """
 
 from __future__ import annotations
@@ -36,20 +41,27 @@ from safetensors.torch import load_file
 GGUF_MAGIC = 0x46554747  # "GGUF" LE
 GGUF_VERSION = 3
 ALIGNMENT = 32
+
+# Q4_0 block format: 2 bytes (f16 scale) + 16 bytes (packed nibbles) = 18 bytes per 32 elements
 Q4_BLOCK_SIZE = 32
-Q4_BLOCK_BYTES = 18  # 2 (f16 scale) + 16 (packed nibbles)
+Q4_BLOCK_BYTES = 18
+
+# Q8_0 block format: 2 bytes (f16 scale) + 32 bytes (signed int8) = 34 bytes per 32 elements
+Q8_BLOCK_SIZE = 32
+Q8_BLOCK_BYTES = 34
 
 # GGML dtype codes matching src/gguf/reader.rs GgmlDtype
 DTYPE_F32 = 0
 DTYPE_F16 = 1
 DTYPE_Q4_0 = 2
+DTYPE_Q8_0 = 8
 
 # ---------------------------------------------------------------------------
 # Quantization strategy
 # ---------------------------------------------------------------------------
 
-# Patterns for tensors that should be quantized to Q4_0 (large linear layers).
-Q4_PATTERNS: list[str] = [
+# Patterns for tensors that should be quantized (large linear layers).
+QUANT_PATTERNS: list[str] = [
     "layers.",  # backbone + FM transformer layers (attention + ffn)
     "mm_audio_embeddings.tok_embeddings.weight",
     "acoustic_transformer.llm_projection.weight",
@@ -77,12 +89,12 @@ WEIGHT_NORM_V_SUFFIX = ".parametrizations.weight.original1"
 
 
 def should_quantize(name: str) -> bool:
-    """Return True if this tensor should be Q4_0 quantized."""
+    """Return True if this tensor should be quantized."""
     # F32 patterns take priority — check exclusions first.
     for pat in F32_PATTERNS:
         if pat in name:
             return False
-    for pat in Q4_PATTERNS:
+    for pat in QUANT_PATTERNS:
         if pat in name:
             return True
     return False
@@ -182,6 +194,63 @@ def q4_byte_size(num_elements: int) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Q8_0 quantization
+# ---------------------------------------------------------------------------
+
+def quantize_q8_0(data: np.ndarray) -> bytes:
+    """Quantize a flat f32 array to Q8_0 format.
+
+    Block layout (34 bytes per 32 elements):
+      - bytes 0-1: f16 scale `d` (little-endian)
+      - bytes 2-33: 32 signed int8 values
+
+    Dequantization: value = scale * int8_value
+    """
+    data = data.astype(np.float32).ravel()
+    n = len(data)
+
+    # Pad to multiple of 32 if needed.
+    remainder = n % Q8_BLOCK_SIZE
+    if remainder != 0:
+        pad = Q8_BLOCK_SIZE - remainder
+        data = np.concatenate([data, np.zeros(pad, dtype=np.float32)])
+        n = len(data)
+
+    n_blocks = n // Q8_BLOCK_SIZE
+    output = bytearray(n_blocks * Q8_BLOCK_BYTES)
+
+    for b in range(n_blocks):
+        block = data[b * Q8_BLOCK_SIZE : (b + 1) * Q8_BLOCK_SIZE]
+        amax = float(np.max(np.abs(block)))
+        d = amax / 127.0
+        inv_d = 1.0 / d if d != 0.0 else 0.0
+
+        # Scale as f16 LE
+        d_f16 = np.float16(d)
+        offset = b * Q8_BLOCK_BYTES
+        struct.pack_into("<e", output, offset, float(d_f16))
+
+        # Quantize to signed int8
+        for i in range(Q8_BLOCK_SIZE):
+            v = float(block[i])
+            q = int(round(v * inv_d))
+            q = max(-128, min(127, q))
+            # Store as unsigned byte (two's complement)
+            output[offset + 2 + i] = q & 0xFF
+
+    return bytes(output)
+
+
+def q8_byte_size(num_elements: int) -> int:
+    """Compute Q8_0 byte size for a given element count (after padding to 32)."""
+    n = num_elements
+    remainder = n % Q8_BLOCK_SIZE
+    if remainder != 0:
+        n += Q8_BLOCK_SIZE - remainder
+    return (n // Q8_BLOCK_SIZE) * Q8_BLOCK_BYTES
+
+
+# ---------------------------------------------------------------------------
 # GGUF v3 writer helpers
 # ---------------------------------------------------------------------------
 
@@ -210,6 +279,7 @@ def align_offset(offset: int) -> int:
 
 def load_and_prepare_tensors(
     model_dir: Path,
+    quant_type: str,
 ) -> list[tuple[str, int, np.ndarray, list[int]]]:
     """Load SafeTensors, fuse weight norms, decide dtype for each tensor.
 
@@ -220,7 +290,23 @@ def load_and_prepare_tensors(
         print(f"Error: {st_path} not found", file=sys.stderr)
         sys.exit(1)
 
+    # Select quantization parameters
+    if quant_type == "q4_0":
+        quantize_fn = quantize_q4_0
+        dtype_code = DTYPE_Q4_0
+        block_size = Q4_BLOCK_SIZE
+        quant_label = "Q4_0"
+    elif quant_type == "q8_0":
+        quantize_fn = quantize_q8_0
+        dtype_code = DTYPE_Q8_0
+        block_size = Q8_BLOCK_SIZE
+        quant_label = "Q8_0"
+    else:
+        print(f"Error: unknown quant type '{quant_type}'", file=sys.stderr)
+        sys.exit(1)
+
     print(f"Loading {st_path} ...")
+    print(f"Quantization: {quant_label}")
     state_dict = load_file(str(st_path), device="cpu")
 
     # -----------------------------------------------------------------------
@@ -271,14 +357,14 @@ def load_and_prepare_tensors(
         arr = tensor.numpy()
 
         if should_quantize(name):
-            data = quantize_q4_0(arr)
+            data = quantize_fn(arr)
             # Adjust shape if padding was needed.
             n_elem = int(np.prod(shape))
-            if n_elem % Q4_BLOCK_SIZE != 0:
-                # Pad last dimension to make total elements divisible by 32.
-                pad_needed = Q4_BLOCK_SIZE - (n_elem % Q4_BLOCK_SIZE)
+            if n_elem % block_size != 0:
+                # Pad last dimension to make total elements divisible by block_size.
+                pad_needed = block_size - (n_elem % block_size)
                 shape[-1] += pad_needed
-            results.append((name, DTYPE_Q4_0, data, shape))
+            results.append((name, dtype_code, data, shape))
         else:
             data = arr.astype(np.float32).tobytes()
             results.append((name, DTYPE_F32, data, shape))
@@ -303,7 +389,7 @@ def write_gguf(
 ) -> None:
     """Write GGUF v3 file from prepared tensors."""
     # Print summary table.
-    dtype_names = {DTYPE_F32: "F32", DTYPE_F16: "F16", DTYPE_Q4_0: "Q4_0"}
+    dtype_names = {DTYPE_F32: "F32", DTYPE_F16: "F16", DTYPE_Q4_0: "Q4_0", DTYPE_Q8_0: "Q8_0"}
     total_data = 0
     print(f"\n{'Tensor':<70} {'Dtype':<6} {'Shape':<25} {'Size':>12}")
     print("-" * 115)
@@ -379,7 +465,7 @@ def write_gguf(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Quantize Voxtral 4B TTS to GGUF v3 with Q4_0"
+        description="Quantize Voxtral 4B TTS to GGUF v3 with Q4_0 or Q8_0"
     )
     parser.add_argument(
         "model_dir",
@@ -390,8 +476,14 @@ def main() -> None:
         "-o",
         "--output",
         type=Path,
-        default=Path("voxtral-tts-q4.gguf"),
-        help="Output GGUF path (default: voxtral-tts-q4.gguf)",
+        default=None,
+        help="Output GGUF path (default: voxtral-tts-{quant_type}.gguf)",
+    )
+    parser.add_argument(
+        "--quant-type",
+        choices=["q4_0", "q8_0"],
+        default="q8_0",
+        help="Quantization type (default: q8_0)",
     )
     parser.add_argument(
         "--dry-run",
@@ -404,7 +496,10 @@ def main() -> None:
         print(f"Error: {args.model_dir} is not a directory", file=sys.stderr)
         sys.exit(1)
 
-    tensors = load_and_prepare_tensors(args.model_dir)
+    if args.output is None:
+        args.output = Path(f"voxtral-tts-{args.quant_type.replace('_', '')}.gguf")
+
+    tensors = load_and_prepare_tensors(args.model_dir, args.quant_type)
     write_gguf(tensors, args.output, dry_run=args.dry_run)
 
 

--- a/src/gguf/linear.rs
+++ b/src/gguf/linear.rs
@@ -1,17 +1,19 @@
-//! Q4_0 quantized linear layer.
+//! Quantized linear layer (Q4_0 and Q8_0).
 //!
 //! [`Q4Linear`] wraps a [`Q4Tensor`] weight matrix and optional f32 bias,
-//! providing a `forward` method that delegates to [`q4_matmul`].
+//! providing a `forward` method that delegates to [`quantized_matmul`].
+//! Despite the "Q4" name (kept for backwards compatibility), it supports
+//! both Q4_0 and Q8_0 quantized weights transparently.
 
 use burn::backend::Wgpu;
 use burn::tensor::Tensor;
 
-use super::op::q4_matmul;
+use super::op::quantized_matmul;
 use super::tensor::Q4Tensor;
 
-/// A linear layer with Q4_0 quantized weights.
+/// A linear layer with quantized weights (Q4_0 or Q8_0).
 ///
-/// Stores weights as `[out_features, in_features]` in Q4_0 format and an
+/// Stores weights as `[out_features, in_features]` in quantized format and an
 /// optional f32 bias vector. The forward pass computes
 /// `x @ weights^T + bias` via the fused dequant+matmul GPU kernel.
 pub struct Q4Linear {
@@ -20,14 +22,15 @@ pub struct Q4Linear {
 }
 
 impl Q4Linear {
-    /// Create a new Q4 linear layer.
+    /// Create a new quantized linear layer.
     ///
     /// `weights` shape must be `[out_features, in_features]`.
+    /// Works with both Q4_0 and Q8_0 quantized tensors.
     pub fn new(weights: Q4Tensor, bias: Option<Tensor<Wgpu, 1>>) -> Self {
         Self { weights, bias }
     }
 
-    /// Access the underlying Q4 weight tensor.
+    /// Access the underlying quantized weight tensor.
     pub fn weights(&self) -> &Q4Tensor {
         &self.weights
     }
@@ -37,7 +40,7 @@ impl Q4Linear {
     /// `x` shape: `[B, M, K]` where `K = in_features`.
     /// Returns shape: `[B, M, N]` where `N = out_features`.
     pub fn forward(&self, x: Tensor<Wgpu, 3>) -> Tensor<Wgpu, 3> {
-        let out = q4_matmul(x, &self.weights);
+        let out = quantized_matmul(x, &self.weights);
         match &self.bias {
             Some(bias) => out + bias.clone().unsqueeze::<3>(),
             None => out,
@@ -45,9 +48,9 @@ impl Q4Linear {
     }
 }
 
-/// Fused Q/K/V projection: stores concatenated Q4 weights and splits output.
+/// Fused Q/K/V projection: stores concatenated quantized weights and splits output.
 ///
-/// Instead of 3 separate Q4 matmul launches for wq, wk, wv, uses a single
+/// Instead of 3 separate matmul launches for wq, wk, wv, uses a single
 /// concatenated weight matrix `[q_out + k_out + v_out, in_features]`.
 /// Reduces kernel launches from 3 to 1 per layer.
 pub struct Q4FusedQKV {
@@ -57,9 +60,9 @@ pub struct Q4FusedQKV {
     v_out: usize,
 }
 
-/// Fused gate+up projection for SwiGLU: stores concatenated w1||w3 Q4 weights.
+/// Fused gate+up projection for SwiGLU: stores concatenated w1||w3 quantized weights.
 ///
-/// Reduces 2 Q4 matmul launches to 1 per FFN layer.
+/// Reduces 2 matmul launches to 1 per FFN layer.
 pub struct Q4FusedGateUp {
     weights: Q4Tensor,
     gate_out: usize,
@@ -67,7 +70,7 @@ pub struct Q4FusedGateUp {
 }
 
 impl Q4FusedGateUp {
-    /// Create from a pre-built concatenated Q4 tensor.
+    /// Create from a pre-built concatenated quantized tensor.
     pub fn new(weights: Q4Tensor, gate_out: usize, up_out: usize) -> Self {
         Self {
             weights,
@@ -76,9 +79,9 @@ impl Q4FusedGateUp {
         }
     }
 
-    /// Forward: single Q4 matmul → split into (gate, up).
+    /// Forward: single quantized matmul -> split into (gate, up).
     pub fn forward(&self, x: Tensor<Wgpu, 3>) -> (Tensor<Wgpu, 3>, Tensor<Wgpu, 3>) {
-        let fused = q4_matmul(x, &self.weights);
+        let fused = quantized_matmul(x, &self.weights);
 
         let gate = fused.clone().narrow(2, 0, self.gate_out);
         let up = fused.narrow(2, self.gate_out, self.up_out);
@@ -88,7 +91,7 @@ impl Q4FusedGateUp {
 }
 
 impl Q4FusedQKV {
-    /// Create from a pre-built concatenated Q4 tensor.
+    /// Create from a pre-built concatenated quantized tensor.
     pub fn new(weights: Q4Tensor, q_out: usize, k_out: usize, v_out: usize) -> Self {
         Self {
             weights,
@@ -98,7 +101,7 @@ impl Q4FusedQKV {
         }
     }
 
-    /// Forward: single Q4 matmul → split into (q, k, v).
+    /// Forward: single quantized matmul -> split into (q, k, v).
     ///
     /// `x` shape: `[B, M, K]`.
     /// Returns: `(q [B, M, q_out], k [B, M, k_out], v [B, M, v_out])`.
@@ -106,7 +109,7 @@ impl Q4FusedQKV {
         &self,
         x: Tensor<Wgpu, 3>,
     ) -> (Tensor<Wgpu, 3>, Tensor<Wgpu, 3>, Tensor<Wgpu, 3>) {
-        let fused = q4_matmul(x, &self.weights);
+        let fused = quantized_matmul(x, &self.weights);
 
         let q = fused.clone().narrow(2, 0, self.q_out);
         let k = fused.clone().narrow(2, self.q_out, self.k_out);

--- a/src/gguf/loader.rs
+++ b/src/gguf/loader.rs
@@ -30,7 +30,7 @@ use super::model::{
 use super::reader::{GgmlDtype, GgufReader, ShardedCursor};
 use super::tensor::Q4Tensor;
 
-/// All Q4 model components with token embeddings still in raw Q4 form.
+/// All Q4 model components with token embeddings still in raw quantized form.
 ///
 /// Used by [`Q4ModelLoader::load_deferred`] to allow freeing the GGUF
 /// reader's memory (potentially >2 GB of shard data) before dequantizing
@@ -43,6 +43,7 @@ pub struct Q4ModelParts {
     pub decoder_norm: RmsNorm<Wgpu>,
     pub tok_embed_q4_bytes: Vec<u8>,
     pub tok_embed_shape: [usize; 2],
+    pub tok_embed_dtype: GgmlDtype,
 }
 
 impl Q4ModelParts {
@@ -54,9 +55,13 @@ impl Q4ModelParts {
     pub fn finalize(self, device: &WgpuDevice) -> Result<Q4VoxtralModel> {
         let [vocab, d_model] = self.tok_embed_shape;
 
-        // Create Q4Tensor on GPU for the lm_head matmul
-        let tok_embed_q4 =
-            Q4Tensor::from_q4_bytes(&self.tok_embed_q4_bytes, [vocab, d_model], device)?;
+        // Create quantized tensor on GPU for the lm_head matmul
+        let tok_embed_q4 = Q4Tensor::from_quantized_bytes(
+            &self.tok_embed_q4_bytes,
+            [vocab, d_model],
+            self.tok_embed_dtype,
+            device,
+        )?;
 
         let decoder = Q4LanguageModel::new_q4_embeddings(
             tok_embed_q4,
@@ -150,7 +155,7 @@ impl<R: Read + Seek> Q4ModelLoader<R> {
         info!("Loading audio-language adapter");
         let adapter = self.load_adapter(device)?;
 
-        // Extract raw Q4 bytes for token embeddings (don't dequantize yet)
+        // Extract raw quantized bytes for token embeddings (don't dequantize yet)
         let tok_name = prefixes::TOK_EMBEDDINGS;
         let tok_info = self
             .reader
@@ -158,6 +163,7 @@ impl<R: Read + Seek> Q4ModelLoader<R> {
             .with_context(|| format!("Tensor '{tok_name}' not found"))?
             .clone();
         let tok_shape = reverse_gguf_dims(tok_info.shape());
+        let tok_embed_dtype = tok_info.dtype();
         let tok_embed_q4_bytes = self.reader.tensor_data(tok_name)?;
 
         info!(layers = 26, "Loading decoder layers");
@@ -184,6 +190,7 @@ impl<R: Read + Seek> Q4ModelLoader<R> {
             decoder_norm,
             tok_embed_q4_bytes,
             tok_embed_shape: [tok_shape[0], tok_shape[1]],
+            tok_embed_dtype,
         })
     }
 
@@ -319,6 +326,12 @@ impl<R: Read + Seek> Q4ModelLoader<R> {
                 let tensor_data = TensorData::new(f32_data, [shape[0], shape[1]]);
                 Ok(Tensor::from_data(tensor_data, device))
             }
+            GgmlDtype::Q8_0 => {
+                let bytes = self.reader.tensor_data(name)?;
+                let f32_data = dequantize_q8_0_cpu(&bytes, shape[0] * shape[1]);
+                let tensor_data = TensorData::new(f32_data, [shape[0], shape[1]]);
+                Ok(Tensor::from_data(tensor_data, device))
+            }
             GgmlDtype::F32 | GgmlDtype::F16 => self.load_f32_tensor(name, device),
             #[allow(unreachable_patterns)]
             other => bail!("Unsupported dtype {other:?} for tok_embeddings"),
@@ -425,7 +438,7 @@ impl<R: Read + Seek> Q4ModelLoader<R> {
 // Shared GGUF loading helpers (used by both ASR and TTS loaders)
 // ---------------------------------------------------------------------------
 
-/// Load a Q4_0 tensor as a [`Q4Linear`] (no bias).
+/// Load a quantized tensor (Q4_0 or Q8_0) as a [`Q4Linear`] (no bias).
 pub(crate) fn gguf_load_q4_linear<R: Read + Seek>(
     reader: &mut GgufReader<R>,
     name: &str,
@@ -436,17 +449,18 @@ pub(crate) fn gguf_load_q4_linear<R: Read + Seek>(
         .with_context(|| format!("Tensor '{name}' not found"))?
         .clone();
 
-    if info.dtype() != GgmlDtype::Q4_0 {
-        bail!("Expected Q4_0 for '{name}', got {:?}", info.dtype());
+    let dtype = info.dtype();
+    if !dtype.is_quantized() {
+        bail!("Expected quantized type (Q4_0 or Q8_0) for '{name}', got {dtype:?}");
     }
 
     let shape = reverse_gguf_dims(info.shape());
     let bytes = reader.tensor_data(name)?;
-    let q4 = Q4Tensor::from_q4_bytes(&bytes, [shape[0], shape[1]], device)?;
-    Ok(Q4Linear::new(q4, None))
+    let tensor = Q4Tensor::from_quantized_bytes(&bytes, [shape[0], shape[1]], dtype, device)?;
+    Ok(Q4Linear::new(tensor, None))
 }
 
-/// Load a Q4_0 tensor with an optional F32 bias as a [`Q4Linear`].
+/// Load a quantized tensor (Q4_0 or Q8_0) with an optional F32 bias as a [`Q4Linear`].
 pub(crate) fn gguf_load_q4_linear_with_optional_bias<R: Read + Seek>(
     reader: &mut GgufReader<R>,
     weight_name: &str,
@@ -458,13 +472,14 @@ pub(crate) fn gguf_load_q4_linear_with_optional_bias<R: Read + Seek>(
         .with_context(|| format!("Tensor '{weight_name}' not found"))?
         .clone();
 
-    if info.dtype() != GgmlDtype::Q4_0 {
-        bail!("Expected Q4_0 for '{weight_name}', got {:?}", info.dtype());
+    let dtype = info.dtype();
+    if !dtype.is_quantized() {
+        bail!("Expected quantized type (Q4_0 or Q8_0) for '{weight_name}', got {dtype:?}");
     }
 
     let shape = reverse_gguf_dims(info.shape());
     let bytes = reader.tensor_data(weight_name)?;
-    let q4 = Q4Tensor::from_q4_bytes(&bytes, [shape[0], shape[1]], device)?;
+    let tensor = Q4Tensor::from_quantized_bytes(&bytes, [shape[0], shape[1]], dtype, device)?;
 
     let bias = if let Some(bias_name) = bias_name {
         if reader.tensor_info(bias_name).is_some() {
@@ -477,7 +492,7 @@ pub(crate) fn gguf_load_q4_linear_with_optional_bias<R: Read + Seek>(
         None
     };
 
-    Ok(Q4Linear::new(q4, bias))
+    Ok(Q4Linear::new(tensor, bias))
 }
 
 /// Load an F32/F16 tensor from GGUF.
@@ -506,7 +521,12 @@ pub(crate) fn gguf_load_f32_tensor<R: Read + Seek, const D: usize>(
                 half::f16::from_bits(bits).to_f32()
             })
             .collect(),
-        GgmlDtype::Q4_0 => bail!("Cannot load Q4_0 tensor '{name}' as f32; use load_q4_linear"),
+        GgmlDtype::Q4_0 | GgmlDtype::Q8_0 => {
+            bail!(
+                "Cannot load {:?} tensor '{name}' as f32; use load_q4_linear",
+                info.dtype()
+            )
+        }
     };
 
     let tensor_data = TensorData::new(data, shape);
@@ -554,6 +574,25 @@ pub(crate) fn dequantize_q4_0_cpu(raw: &[u8], num_elements: usize) -> Vec<f32> {
             let hi = ((byte >> 4) & 0x0F) as f32 - 8.0;
             output[base + i] = lo * d;
             output[base + i + 16] = hi * d;
+        }
+    }
+    output
+}
+
+/// Dequantize Q8_0 blocks on CPU, returning `num_elements` f32 values.
+///
+/// Q8_0 block: 2 bytes (f16 scale) + 32 bytes (signed int8 values) = 34 bytes per block.
+/// Dequant: value = scale * int8_value.
+pub(crate) fn dequantize_q8_0_cpu(raw: &[u8], num_elements: usize) -> Vec<f32> {
+    let num_blocks = num_elements / 32;
+    let mut output = vec![0.0f32; num_elements];
+    for block_idx in 0..num_blocks {
+        let offset = block_idx * 34;
+        let d = half::f16::from_bits(u16::from_le_bytes([raw[offset], raw[offset + 1]])).to_f32();
+        let base = block_idx * 32;
+        for i in 0..32 {
+            let val = raw[offset + 2 + i] as i8;
+            output[base + i] = d * val as f32;
         }
     }
     output

--- a/src/gguf/mod.rs
+++ b/src/gguf/mod.rs
@@ -23,7 +23,7 @@ pub use model::{
     Q4AdaRmsNorm, Q4Adapter, Q4Attention, Q4AudioEncoder, Q4DecoderLayer, Q4EncoderLayer,
     Q4FeedForward, Q4LanguageModel, Q4VoxtralModel,
 };
-pub use op::q4_matmul;
+pub use op::{q4_matmul, q8_matmul, quantized_matmul};
 pub use reader::{GgmlDtype, GgufReader, GgufTensorInfo, ShardedCursor};
 pub use tensor::Q4Tensor;
 pub use tts_loader::{Q4TtsModelLoader, Q4TtsModelParts};

--- a/src/gguf/model.rs
+++ b/src/gguf/model.rs
@@ -211,15 +211,20 @@ impl Q4Attention {
         fused_bytes.extend_from_slice(&wk_bytes);
         fused_bytes.extend_from_slice(&wv_bytes);
 
-        if let Ok(fused) =
-            super::tensor::Q4Tensor::from_q4_bytes(&fused_bytes, [q_out + k_out + v_out, k], device)
-        {
+        let dtype = self.wq.weights().dtype();
+        if let Ok(fused) = super::tensor::Q4Tensor::from_quantized_bytes(
+            &fused_bytes,
+            [q_out + k_out + v_out, k],
+            dtype,
+            device,
+        ) {
             self.fused_qkv = Some(super::linear::Q4FusedQKV::new(fused, q_out, k_out, v_out));
             tracing::debug!(
                 q_out,
                 k_out,
                 v_out,
-                "Fused QKV weights into single Q4 tensor"
+                ?dtype,
+                "Fused QKV weights into single quantized tensor"
             );
         }
     }
@@ -310,9 +315,13 @@ impl Q4FeedForward {
         fused_bytes.extend_from_slice(&w1_bytes);
         fused_bytes.extend_from_slice(&w3_bytes);
 
-        if let Ok(fused) =
-            super::tensor::Q4Tensor::from_q4_bytes(&fused_bytes, [w1_out + w3_out, k], device)
-        {
+        let dtype = self.w1.weights().dtype();
+        if let Ok(fused) = super::tensor::Q4Tensor::from_quantized_bytes(
+            &fused_bytes,
+            [w1_out + w3_out, k],
+            dtype,
+            device,
+        ) {
             self.fused_gate_up = Some(super::linear::Q4FusedGateUp::new(fused, w1_out, w3_out));
         }
     }
@@ -572,6 +581,8 @@ pub(crate) enum TokEmbedStore {
     Q4 {
         lm_head: Q4Linear,
         cpu_bytes: Vec<u8>,
+        /// The quantization type of the CPU bytes (Q4_0 or Q8_0).
+        quant_dtype: super::reader::GgmlDtype,
     },
 }
 
@@ -605,9 +616,9 @@ impl Q4LanguageModel {
         }
     }
 
-    /// Create a new Q4 language model with Q4 token embeddings.
+    /// Create a new Q4 language model with quantized token embeddings.
     ///
-    /// Keeps a CPU copy of the Q4 bytes for embed_tokens (small row lookups)
+    /// Keeps a CPU copy of the quantized bytes for embed_tokens (small row lookups)
     /// and a Q4Linear on GPU for the lm_head (full vocab matmul).
     #[allow(clippy::too_many_arguments)]
     pub fn new_q4_embeddings(
@@ -619,10 +630,12 @@ impl Q4LanguageModel {
         layers: Vec<Q4DecoderLayer>,
         norm: RmsNorm<Wgpu>,
     ) -> Self {
+        let quant_dtype = tok_embed_q4.dtype();
         Self {
             tok_embeddings: TokEmbedStore::Q4 {
                 lm_head: Q4Linear::new(tok_embed_q4, None),
                 cpu_bytes: tok_embed_bytes,
+                quant_dtype,
             },
             rope,
             layers,
@@ -645,13 +658,17 @@ impl Q4LanguageModel {
                 let selected = embed.clone().select(0, flat_ids);
                 selected.reshape([batch, seq, self.d_model])
             }
-            TokEmbedStore::Q4 { cpu_bytes, .. } => {
+            TokEmbedStore::Q4 {
+                cpu_bytes,
+                quant_dtype,
+                ..
+            } => {
                 let [batch, seq] = token_ids.dims();
                 let id_data = token_ids.into_data();
                 let ids: Vec<i32> = id_data
                     .to_vec()
                     .expect("tensor data extraction for token IDs");
-                self.embed_from_q4_bytes(cpu_bytes, &ids, batch, seq)
+                self.embed_from_quantized_bytes(cpu_bytes, *quant_dtype, &ids, batch, seq)
             }
         }
     }
@@ -668,22 +685,30 @@ impl Q4LanguageModel {
                 let selected = embed.clone().select(0, flat_ids);
                 selected.reshape([batch, seq, self.d_model])
             }
-            TokEmbedStore::Q4 { cpu_bytes, .. } => {
-                self.embed_from_q4_bytes(cpu_bytes, ids, batch, seq)
-            }
+            TokEmbedStore::Q4 {
+                cpu_bytes,
+                quant_dtype,
+                ..
+            } => self.embed_from_quantized_bytes(cpu_bytes, *quant_dtype, ids, batch, seq),
         }
     }
 
-    /// Dequantize specific rows from CPU Q4 bytes.
-    fn embed_from_q4_bytes(
+    /// Dequantize specific rows from CPU quantized bytes (Q4_0 or Q8_0).
+    fn embed_from_quantized_bytes(
         &self,
         cpu_bytes: &[u8],
+        dtype: super::reader::GgmlDtype,
         ids: &[i32],
         batch: usize,
         seq: usize,
     ) -> Tensor<Wgpu, 3> {
         let blocks_per_row = self.d_model / 32;
-        let bytes_per_row = blocks_per_row * 18;
+        let block_bytes = match dtype {
+            super::reader::GgmlDtype::Q4_0 => 18,
+            super::reader::GgmlDtype::Q8_0 => 34,
+            _ => unreachable!("embed_from_quantized_bytes only supports Q4_0 and Q8_0"),
+        };
+        let bytes_per_row = blocks_per_row * block_bytes;
         let mut output = vec![0.0f32; ids.len() * self.d_model];
 
         for (i, &id) in ids.iter().enumerate() {
@@ -691,17 +716,39 @@ impl Q4LanguageModel {
             let row_bytes = &cpu_bytes[row_offset..row_offset + bytes_per_row];
             let out_slice = &mut output[i * self.d_model..(i + 1) * self.d_model];
 
-            for block in 0..blocks_per_row {
-                let bo = block * 18;
-                let d =
-                    half::f16::from_bits(u16::from_le_bytes([row_bytes[bo], row_bytes[bo + 1]]))
+            match dtype {
+                super::reader::GgmlDtype::Q4_0 => {
+                    for block in 0..blocks_per_row {
+                        let bo = block * 18;
+                        let d = half::f16::from_bits(u16::from_le_bytes([
+                            row_bytes[bo],
+                            row_bytes[bo + 1],
+                        ]))
                         .to_f32();
-                let base = block * 32;
-                for j in 0..16 {
-                    let byte = row_bytes[bo + 2 + j];
-                    out_slice[base + j] = ((byte & 0x0F) as f32 - 8.0) * d;
-                    out_slice[base + j + 16] = (((byte >> 4) & 0x0F) as f32 - 8.0) * d;
+                        let base = block * 32;
+                        for j in 0..16 {
+                            let byte = row_bytes[bo + 2 + j];
+                            out_slice[base + j] = ((byte & 0x0F) as f32 - 8.0) * d;
+                            out_slice[base + j + 16] = (((byte >> 4) & 0x0F) as f32 - 8.0) * d;
+                        }
+                    }
                 }
+                super::reader::GgmlDtype::Q8_0 => {
+                    for block in 0..blocks_per_row {
+                        let bo = block * 34;
+                        let d = half::f16::from_bits(u16::from_le_bytes([
+                            row_bytes[bo],
+                            row_bytes[bo + 1],
+                        ]))
+                        .to_f32();
+                        let base = block * 32;
+                        for j in 0..32 {
+                            let val = row_bytes[bo + 2 + j] as i8;
+                            out_slice[base + j] = d * val as f32;
+                        }
+                    }
+                }
+                _ => unreachable!(),
             }
         }
 

--- a/src/gguf/op.rs
+++ b/src/gguf/op.rs
@@ -1,14 +1,16 @@
-//! Fused Q4_0 dequant+matmul GPU kernel launch.
+//! Fused quantized dequant+matmul GPU kernel launch.
 //!
-//! [`q4_matmul`] launches a WGSL compute shader to perform
+//! [`q4_matmul`] and [`q8_matmul`] launch WGSL compute shaders to perform
 //! `output[B, M, N] = input[B, M, K] × weights[N, K]^T` where weights are in
-//! Q4_0 format with shape `[N, K]` (out_features, in_features).
+//! Q4_0 or Q8_0 format with shape `[N, K]` (out_features, in_features).
+//!
+//! [`quantized_matmul`] auto-dispatches based on the tensor's dtype.
 //!
 //! Two kernel variants are dispatched based on M:
-//! - **M ≤ threshold**: Tiled kernel with shared memory (shader.wgsl).
+//! - **M ≤ threshold**: Tiled kernel with shared memory (shader.wgsl / shader_q8.wgsl).
 //!   Cooperatively loads the input vector into workgroup shared memory,
 //!   eliminating redundant global reads. Uses 1D (128,1,1) workgroups.
-//! - **M > threshold**: Naive kernel (shader_naive.wgsl).
+//! - **M > threshold**: Naive kernel (shader_naive.wgsl / shader_naive_q8.wgsl).
 //!   One thread per output element with (16,16) workgroups — better for
 //!   multi-row matmuls where the 2D layout fills the GPU efficiently.
 //!
@@ -26,13 +28,14 @@ use cubecl::prelude::KernelId;
 use cubecl::server::{Bindings, CubeCount};
 use cubecl::CubeTask;
 
+use super::reader::GgmlDtype;
 use super::tensor::Q4Tensor;
 
 /// M threshold: use tiled kernel when M ≤ this, naive kernel otherwise.
 #[cfg(not(target_family = "wasm"))]
 const TILED_M_THRESHOLD: usize = 4;
 
-// -- Tiled kernel (shared memory, good for M=1 decode) --
+// -- Tiled kernels (shared memory, good for M=1 decode) --
 
 #[cfg(not(target_family = "wasm"))]
 const TILED_WG_X: u32 = 128;
@@ -54,7 +57,24 @@ impl KernelSource for Q4MatmulTiledKernel {
     }
 }
 
-// -- Naive kernel (one thread per element, good for M>1 prefill/encoder) --
+#[cfg(not(target_family = "wasm"))]
+struct Q8MatmulTiledKernel {
+    workgroup_size_x: u32,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl KernelSource for Q8MatmulTiledKernel {
+    fn source(&self) -> SourceTemplate {
+        SourceTemplate::new(include_str!("shader_q8.wgsl"))
+            .register("workgroup_size_x", self.workgroup_size_x.to_string())
+    }
+
+    fn id(&self) -> KernelId {
+        KernelId::new::<Self>().info(self.workgroup_size_x)
+    }
+}
+
+// -- Naive kernels (one thread per element, good for M>1 prefill/encoder) --
 
 const NAIVE_WG_X: u32 = 16;
 const NAIVE_WG_Y: u32 = 16;
@@ -73,6 +93,35 @@ impl KernelSource for Q4MatmulNaiveKernel {
 
     fn id(&self) -> KernelId {
         KernelId::new::<Self>().info(self.workgroup_size_x * 1000 + self.workgroup_size_y)
+    }
+}
+
+struct Q8MatmulNaiveKernel {
+    workgroup_size_x: u32,
+    workgroup_size_y: u32,
+}
+
+impl KernelSource for Q8MatmulNaiveKernel {
+    fn source(&self) -> SourceTemplate {
+        SourceTemplate::new(include_str!("shader_naive_q8.wgsl"))
+            .register("workgroup_size_x", self.workgroup_size_x.to_string())
+            .register("workgroup_size_y", self.workgroup_size_y.to_string())
+    }
+
+    fn id(&self) -> KernelId {
+        KernelId::new::<Self>().info(self.workgroup_size_x * 1000 + self.workgroup_size_y)
+    }
+}
+
+/// Fused quantized dequant+matmul on GPU, auto-dispatching by dtype.
+///
+/// Computes `output[B, M, N] = input[B, M, K] × weights[N, K]^T`.
+/// Supports both Q4_0 and Q8_0 weight tensors.
+pub fn quantized_matmul(input: Tensor<Wgpu, 3>, weights: &Q4Tensor) -> Tensor<Wgpu, 3> {
+    match weights.dtype() {
+        GgmlDtype::Q4_0 => q4_matmul(input, weights),
+        GgmlDtype::Q8_0 => q8_matmul(input, weights),
+        other => panic!("quantized_matmul: unsupported dtype {other:?}"),
     }
 }
 
@@ -123,7 +172,7 @@ pub fn q4_matmul(input: Tensor<Wgpu, 3>, weights: &Q4Tensor) -> Tensor<Wgpu, 3> 
         .with_buffer(output_handle.clone().binding())
         .with_buffer(info_handle.binding());
 
-    dispatch(&client, b, m, n, bindings);
+    dispatch_q4(&client, b, m, n, bindings);
 
     // Wrap output handle in a CubeTensor → Tensor
     let output_tensor = CubeTensor::new_contiguous(
@@ -136,12 +185,71 @@ pub fn q4_matmul(input: Tensor<Wgpu, 3>, weights: &Q4Tensor) -> Tensor<Wgpu, 3> 
     Tensor::from_primitive(TensorPrimitive::Float(output_tensor))
 }
 
-/// Dispatch the appropriate kernel variant.
+/// Fused Q8_0 dequant+matmul on GPU.
 ///
-/// On native: tiled for M ≤ 4 (decoder), naive for M > 4 (encoder/prefill).
-/// On WASM: always naive to avoid CubeCL bind group layout issues.
+/// Computes `output[B, M, N] = input[B, M, K] × weights[N, K]^T` where weights
+/// are stored in Q8_0 block format on the GPU with shape `[N, K]`
+/// (out_features, in_features), matching PyTorch/GGUF convention.
+pub fn q8_matmul(input: Tensor<Wgpu, 3>, weights: &Q4Tensor) -> Tensor<Wgpu, 3> {
+    // Convert Tensor → CubeTensor and ensure contiguous layout
+    let cube_input: CubeTensor<WgpuRuntime> = input.into_primitive().tensor();
+    let cube_input = into_contiguous(cube_input);
+
+    // Extract dimensions
+    assert_eq!(cube_input.shape.num_dims(), 3, "Input must be 3D [B, M, K]");
+    let b = cube_input.shape.dims[0];
+    let m = cube_input.shape.dims[1];
+    let k = cube_input.shape.dims[2];
+    let [n, wk] = weights.shape();
+    assert_eq!(
+        k, wk,
+        "K dimension mismatch: input has {k}, weights have {wk}"
+    );
+
+    let client = cube_input.client.clone();
+    let device = cube_input.device.clone();
+    let blocks_per_row = k / 32;
+
+    // Allocate output buffer (B × M × N × 4 bytes for f32)
+    let output_handle = client.empty(b * m * n * 4);
+
+    // Info buffer: [B, M, K, N, blocks_per_row]
+    let info: [u32; 5] = [
+        b as u32,
+        m as u32,
+        k as u32,
+        n as u32,
+        blocks_per_row as u32,
+    ];
+    let info_bytes: Vec<u8> = info.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let info_handle = client.create_from_slice(&info_bytes);
+
+    let bindings = Bindings::new()
+        .with_buffer(weights.handle.clone().binding())
+        .with_buffer(cube_input.handle.clone().binding())
+        .with_buffer(output_handle.clone().binding())
+        .with_buffer(info_handle.binding());
+
+    dispatch_q8(&client, b, m, n, bindings);
+
+    // Wrap output handle in a CubeTensor → Tensor
+    let output_tensor = CubeTensor::new_contiguous(
+        client,
+        device,
+        burn::prelude::Shape::from(vec![b, m, n]),
+        output_handle,
+        DType::F32,
+    );
+    Tensor::from_primitive(TensorPrimitive::Float(output_tensor))
+}
+
+// ---------------------------------------------------------------------------
+// Q4 dispatch
+// ---------------------------------------------------------------------------
+
+/// Dispatch the appropriate Q4 kernel variant.
 #[cfg(not(target_family = "wasm"))]
-fn dispatch(
+fn dispatch_q4(
     client: &cubecl::client::ComputeClient<WgpuRuntime>,
     b: usize,
     m: usize,
@@ -165,22 +273,22 @@ fn dispatch(
             )
             .expect("Q4 tiled matmul kernel launch failed");
     } else {
-        dispatch_naive(client, b, m, n, bindings);
+        dispatch_q4_naive(client, b, m, n, bindings);
     }
 }
 
 #[cfg(target_family = "wasm")]
-fn dispatch(
+fn dispatch_q4(
     client: &cubecl::client::ComputeClient<WgpuRuntime>,
     b: usize,
     m: usize,
     n: usize,
     bindings: Bindings,
 ) {
-    dispatch_naive(client, b, m, n, bindings);
+    dispatch_q4_naive(client, b, m, n, bindings);
 }
 
-fn dispatch_naive(
+fn dispatch_q4_naive(
     client: &cubecl::client::ComputeClient<WgpuRuntime>,
     b: usize,
     m: usize,
@@ -203,4 +311,74 @@ fn dispatch_naive(
             bindings,
         )
         .expect("Q4 naive matmul kernel launch failed");
+}
+
+// ---------------------------------------------------------------------------
+// Q8 dispatch
+// ---------------------------------------------------------------------------
+
+/// Dispatch the appropriate Q8 kernel variant.
+#[cfg(not(target_family = "wasm"))]
+fn dispatch_q8(
+    client: &cubecl::client::ComputeClient<WgpuRuntime>,
+    b: usize,
+    m: usize,
+    n: usize,
+    bindings: Bindings,
+) {
+    if m <= TILED_M_THRESHOLD {
+        let kernel = SourceKernel::new(
+            Q8MatmulTiledKernel {
+                workgroup_size_x: TILED_WG_X,
+            },
+            CubeDim::new_1d(TILED_WG_X),
+        );
+        let wg_x = n.div_ceil(TILED_WG_X as usize) as u32;
+        let wg_y = (b * m) as u32;
+        client
+            .launch(
+                Box::new(kernel) as Box<dyn CubeTask<AutoCompiler>>,
+                CubeCount::new_2d(wg_x, wg_y),
+                bindings,
+            )
+            .expect("Q8 tiled matmul kernel launch failed");
+    } else {
+        dispatch_q8_naive(client, b, m, n, bindings);
+    }
+}
+
+#[cfg(target_family = "wasm")]
+fn dispatch_q8(
+    client: &cubecl::client::ComputeClient<WgpuRuntime>,
+    b: usize,
+    m: usize,
+    n: usize,
+    bindings: Bindings,
+) {
+    dispatch_q8_naive(client, b, m, n, bindings);
+}
+
+fn dispatch_q8_naive(
+    client: &cubecl::client::ComputeClient<WgpuRuntime>,
+    b: usize,
+    m: usize,
+    n: usize,
+    bindings: Bindings,
+) {
+    let kernel = SourceKernel::new(
+        Q8MatmulNaiveKernel {
+            workgroup_size_x: NAIVE_WG_X,
+            workgroup_size_y: NAIVE_WG_Y,
+        },
+        CubeDim::new_2d(NAIVE_WG_X, NAIVE_WG_Y),
+    );
+    let wg_x = n.div_ceil(NAIVE_WG_X as usize) as u32;
+    let wg_y = (b * m).div_ceil(NAIVE_WG_Y as usize) as u32;
+    client
+        .launch(
+            Box::new(kernel) as Box<dyn CubeTask<AutoCompiler>>,
+            CubeCount::new_2d(wg_x, wg_y),
+            bindings,
+        )
+        .expect("Q8 naive matmul kernel launch failed");
 }

--- a/src/gguf/reader.rs
+++ b/src/gguf/reader.rs
@@ -22,6 +22,8 @@ pub enum GgmlDtype {
     F16,
     /// 4-bit quantization, block size 32 (18 bytes per block).
     Q4_0,
+    /// 8-bit quantization, block size 32 (34 bytes per block).
+    Q8_0,
 }
 
 impl GgmlDtype {
@@ -30,6 +32,7 @@ impl GgmlDtype {
             0 => Ok(Self::F32),
             1 => Ok(Self::F16),
             2 => Ok(Self::Q4_0),
+            8 => Ok(Self::Q8_0),
             other => bail!("Unsupported GGML dtype code: {other}"),
         }
     }
@@ -44,7 +47,17 @@ impl GgmlDtype {
                 let num_blocks = num_elements / 32;
                 num_blocks * 18
             }
+            Self::Q8_0 => {
+                // 34 bytes per block of 32 elements: 2 (f16 scale) + 32 (int8 values)
+                let num_blocks = num_elements / 32;
+                num_blocks * 34
+            }
         }
+    }
+
+    /// Returns true if this is a block-quantized type (Q4_0 or Q8_0).
+    pub fn is_quantized(&self) -> bool {
+        matches!(self, Self::Q4_0 | Self::Q8_0)
     }
 }
 

--- a/src/gguf/shader_naive_q8.wgsl
+++ b/src/gguf/shader_naive_q8.wgsl
@@ -1,0 +1,49 @@
+// Q8_0 Dequantization + Matrix Multiplication (naive variant, one thread per element)
+// Q8_0: 34 bytes/block = 2 (f16 scale) + 32 (int8 values)
+
+@group(0) @binding(0) var<storage, read_write> weights: array<u32>;
+@group(0) @binding(1) var<storage, read_write> input: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+@group(0) @binding(3) var<storage, read_write> info: array<u32>;
+const Q8_BLOCK_BYTES: u32 = 34u;
+
+fn read_u32_unaligned(byte_offset: u32) -> u32 {
+    let word = byte_offset >> 2u;
+    let shift = (byte_offset & 3u) << 3u;
+    if (shift == 0u) { return weights[word]; }
+    return (weights[word] >> shift) | (weights[word + 1u] << (32u - shift));
+}
+fn read_f16_scale(block_byte_offset: u32) -> f32 {
+    let bits = read_u32_unaligned(block_byte_offset) & 0xFFFFu;
+    return unpack2x16float(bits).x;
+}
+fn extract_i8(word: u32, byte_idx: u32) -> f32 {
+    let raw = (word >> (byte_idx * 8u)) & 0xFFu;
+    return f32(i32(raw) - select(0, 256, raw >= 128u));
+}
+
+@compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let B = info[0]; let M = info[1]; let K = info[2]; let N = info[3];
+    let blocks_per_row = info[4];
+    let n = gid.x; let bm = gid.y; let m = bm % M; let b = bm / M;
+    if (n >= N || b >= B) { return; }
+    var acc: f32 = 0.0;
+    let input_base = b * M * K + m * K;
+    for (var blk: u32 = 0u; blk < blocks_per_row; blk = blk + 1u) {
+        let global_block = n * blocks_per_row + blk;
+        let block_byte = global_block * Q8_BLOCK_BYTES;
+        let scale = read_f16_scale(block_byte);
+        let k_base = blk * 32u;
+        let data_start = block_byte + 2u;
+        for (var wi: u32 = 0u; wi < 8u; wi = wi + 1u) {
+            let packed = read_u32_unaligned(data_start + wi * 4u);
+            let base_i = wi * 4u;
+            let k_off = input_base + k_base;
+            let w = vec4<f32>(extract_i8(packed,0u),extract_i8(packed,1u),extract_i8(packed,2u),extract_i8(packed,3u)) * scale;
+            let inp = vec4<f32>(input[k_off+base_i],input[k_off+base_i+1u],input[k_off+base_i+2u],input[k_off+base_i+3u]);
+            acc += dot(w, inp);
+        }
+    }
+    output[b * M * N + m * N + n] = acc;
+}

--- a/src/gguf/shader_q8.wgsl
+++ b/src/gguf/shader_q8.wgsl
@@ -1,0 +1,75 @@
+// Q8_0 Dequantization + Matrix Multiplication Compute Shader (tiled variant)
+//
+// Q8_0 block layout (34 bytes per 32 elements):
+//   - bytes 0-1: f16 scale
+//   - bytes 2-33: 32 signed int8 quantized values
+// Dequantization: value = scale * i8_value
+
+@group(0) @binding(0) var<storage, read_write> weights: array<u32>;
+@group(0) @binding(1) var<storage, read_write> input: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+@group(0) @binding(3) var<storage, read_write> info: array<u32>;
+
+const TILE_K: u32 = 512u;
+const Q8_BLOCK_BYTES: u32 = 34u;
+var<workgroup> shared_input: array<f32, 512>;
+
+fn read_u32_unaligned(byte_offset: u32) -> u32 {
+    let word = byte_offset >> 2u;
+    let shift = (byte_offset & 3u) << 3u;
+    if (shift == 0u) { return weights[word]; }
+    return (weights[word] >> shift) | (weights[word + 1u] << (32u - shift));
+}
+fn read_f16_scale(block_byte_offset: u32) -> f32 {
+    let bits = read_u32_unaligned(block_byte_offset) & 0xFFFFu;
+    return unpack2x16float(bits).x;
+}
+fn extract_i8(word: u32, byte_idx: u32) -> f32 {
+    let raw = (word >> (byte_idx * 8u)) & 0xFFu;
+    return f32(i32(raw) - select(0, 256, raw >= 128u));
+}
+
+@compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+    @builtin(local_invocation_id) lid: vec3<u32>,
+) {
+    let B = info[0]; let M = info[1]; let K = info[2]; let N = info[3];
+    let blocks_per_row = info[4];
+    let n = gid.x; let bm = gid.y; let m = bm % M; let b = bm / M;
+    let valid = b < B;
+    var acc: f32 = 0.0;
+    let input_base = select(0u, b * M * K + m * K, valid);
+    let wg_size = {{ workgroup_size_x }}u;
+    let num_tiles = (K + TILE_K - 1u) / TILE_K;
+
+    for (var tile: u32 = 0u; tile < num_tiles; tile = tile + 1u) {
+        let tile_start = tile * TILE_K;
+        for (var k_local: u32 = lid.x; k_local < TILE_K; k_local = k_local + wg_size) {
+            let k_global = tile_start + k_local;
+            if (valid && k_global < K) { shared_input[k_local] = input[input_base + k_global]; }
+        }
+        workgroupBarrier();
+        if (valid && n < N) {
+            let tile_end = min(tile_start + TILE_K, K);
+            let blocks_in_tile = (tile_end - tile_start) / 32u;
+            let block_base = tile_start / 32u;
+            for (var blk: u32 = 0u; blk < blocks_in_tile; blk = blk + 1u) {
+                let global_block = n * blocks_per_row + block_base + blk;
+                let block_byte = global_block * Q8_BLOCK_BYTES;
+                let scale = read_f16_scale(block_byte);
+                let k_base = blk * 32u;
+                let data_start = block_byte + 2u;
+                for (var wi: u32 = 0u; wi < 8u; wi = wi + 1u) {
+                    let packed = read_u32_unaligned(data_start + wi * 4u);
+                    let base_i = wi * 4u;
+                    let w = vec4<f32>(extract_i8(packed,0u),extract_i8(packed,1u),extract_i8(packed,2u),extract_i8(packed,3u)) * scale;
+                    let inp = vec4<f32>(shared_input[k_base+base_i],shared_input[k_base+base_i+1u],shared_input[k_base+base_i+2u],shared_input[k_base+base_i+3u]);
+                    acc += dot(w, inp);
+                }
+            }
+        }
+        workgroupBarrier();
+    }
+    if (n < N && b < B) { output[b * M * N + m * N + n] = acc; }
+}

--- a/src/gguf/tensor.rs
+++ b/src/gguf/tensor.rs
@@ -1,6 +1,6 @@
-//! Q4_0 quantized weight tensor stored on GPU.
+//! Quantized weight tensor stored on GPU (Q4_0 and Q8_0).
 //!
-//! [`Q4Tensor`] uploads raw Q4_0 blocks to a GPU storage buffer and provides
+//! [`Q4Tensor`] uploads raw quantized blocks to a GPU storage buffer and provides
 //! a [`dequantize`](Q4Tensor::dequantize) method for diagnostics/testing.
 //! The primary inference path is [`q4_matmul`](super::op::q4_matmul), which
 //! dequantizes on-the-fly inside a fused compute shader.
@@ -13,15 +13,26 @@ use cubecl::client::ComputeClient;
 use cubecl::server::Handle;
 use cubecl::Runtime;
 
-/// A Q4_0 quantized weight tensor living on GPU.
+use super::reader::GgmlDtype;
+
+/// Block constants for Q4_0: 32 elements per block, 18 bytes per block.
+pub const Q4_BLOCK_SIZE: usize = 32;
+pub const Q4_BLOCK_BYTES: usize = 18;
+
+/// Block constants for Q8_0: 32 elements per block, 34 bytes per block.
+pub const Q8_BLOCK_SIZE: usize = 32;
+pub const Q8_BLOCK_BYTES: usize = 34;
+
+/// A quantized weight tensor living on GPU (supports Q4_0 and Q8_0).
 ///
-/// The buffer contains raw Q4_0 blocks (18 bytes per block of 32 elements),
-/// laid out exactly as in GGUF. The WGSL shader interprets the buffer as
-/// `array<f16>` with 9 f16 slots per block.
+/// For Q4_0: the buffer contains raw Q4_0 blocks (18 bytes per block of 32 elements).
+/// For Q8_0: the buffer contains raw Q8_0 blocks (34 bytes per block of 32 elements).
+/// Both are laid out exactly as in GGUF.
 pub struct Q4Tensor {
     pub(crate) handle: Handle,
     shape: [usize; 2],
     num_blocks: usize,
+    dtype: GgmlDtype,
     client: ComputeClient<WgpuRuntime>,
     device: WgpuDevice,
 }
@@ -33,24 +44,53 @@ impl Q4Tensor {
     /// convention. `raw_bytes` must contain exactly `(N * K / 32) * 18` bytes.
     /// The element count `N * K` must be divisible by 32.
     pub fn from_q4_bytes(raw_bytes: &[u8], shape: [usize; 2], device: &WgpuDevice) -> Result<Self> {
+        Self::from_quantized_bytes(raw_bytes, shape, GgmlDtype::Q4_0, device)
+    }
+
+    /// Upload raw Q8_0 bytes to a GPU storage buffer.
+    ///
+    /// Shape is `[N, K]` = `[out_features, in_features]`, matching PyTorch/GGUF
+    /// convention. `raw_bytes` must contain exactly `(N * K / 32) * 34` bytes.
+    /// The element count `N * K` must be divisible by 32.
+    pub fn from_q8_bytes(raw_bytes: &[u8], shape: [usize; 2], device: &WgpuDevice) -> Result<Self> {
+        Self::from_quantized_bytes(raw_bytes, shape, GgmlDtype::Q8_0, device)
+    }
+
+    /// Upload raw quantized bytes to a GPU storage buffer (Q4_0 or Q8_0).
+    pub fn from_quantized_bytes(
+        raw_bytes: &[u8],
+        shape: [usize; 2],
+        dtype: GgmlDtype,
+        device: &WgpuDevice,
+    ) -> Result<Self> {
         let [n, k] = shape;
         let num_elements = k * n;
+        let block_size = match dtype {
+            GgmlDtype::Q4_0 => Q4_BLOCK_SIZE,
+            GgmlDtype::Q8_0 => Q8_BLOCK_SIZE,
+            _ => anyhow::bail!("from_quantized_bytes only supports Q4_0 and Q8_0, got {dtype:?}"),
+        };
+        let block_bytes = match dtype {
+            GgmlDtype::Q4_0 => Q4_BLOCK_BYTES,
+            GgmlDtype::Q8_0 => Q8_BLOCK_BYTES,
+            _ => unreachable!(),
+        };
+
         ensure!(
-            num_elements % 32 == 0,
-            "Q4_0 requires element count divisible by 32, got {num_elements}"
+            num_elements % block_size == 0,
+            "{dtype:?} requires element count divisible by {block_size}, got {num_elements}"
         );
-        let num_blocks = num_elements / 32;
-        let expected_bytes = num_blocks * 18;
+        let num_blocks = num_elements / block_size;
+        let expected_bytes = num_blocks * block_bytes;
         ensure!(
             raw_bytes.len() == expected_bytes,
-            "Q4_0 byte count mismatch: expected {expected_bytes} for {num_blocks} blocks, got {}",
+            "{dtype:?} byte count mismatch: expected {expected_bytes} for {num_blocks} blocks, got {}",
             raw_bytes.len()
         );
 
         let client = WgpuRuntime::client(device);
 
         // Pad to 4-byte alignment for array<u32> access in the WGSL shader.
-        // Q4_0 blocks are 18 bytes, so total size may not be a multiple of 4.
         let padded = if !raw_bytes.len().is_multiple_of(4) {
             let pad = 4 - (raw_bytes.len() % 4);
             let mut buf = raw_bytes.to_vec();
@@ -65,6 +105,7 @@ impl Q4Tensor {
             handle,
             shape,
             num_blocks,
+            dtype,
             client,
             device: device.clone(),
         })
@@ -75,18 +116,32 @@ impl Q4Tensor {
         self.shape
     }
 
-    /// Number of Q4_0 blocks in the tensor.
+    /// Number of quantized blocks in the tensor.
     pub fn num_blocks(&self) -> usize {
         self.num_blocks
     }
 
-    /// Read raw Q4_0 bytes from GPU.
+    /// The quantization dtype (Q4_0 or Q8_0).
+    pub fn dtype(&self) -> GgmlDtype {
+        self.dtype
+    }
+
+    /// Bytes per block for this tensor's quantization type.
+    pub fn block_bytes(&self) -> usize {
+        match self.dtype {
+            GgmlDtype::Q4_0 => Q4_BLOCK_BYTES,
+            GgmlDtype::Q8_0 => Q8_BLOCK_BYTES,
+            _ => unreachable!("Q4Tensor should only hold Q4_0 or Q8_0"),
+        }
+    }
+
+    /// Read raw quantized bytes from GPU.
     ///
-    /// Returns exactly `num_blocks * 18` bytes (may include padding at end
+    /// Returns exactly `num_blocks * block_bytes` bytes (may include padding at end
     /// that was added for 4-byte alignment).
     pub fn read_bytes(&self) -> Vec<u8> {
         let raw = self.client.read_one(self.handle.clone());
-        let expected = self.num_blocks * 18;
+        let expected = self.num_blocks * self.block_bytes();
         assert!(
             raw.len() >= expected,
             "Q4Tensor::read_bytes: GPU buffer shorter than expected: got {}, expected {expected}",
@@ -95,7 +150,7 @@ impl Q4Tensor {
         raw[..expected].to_vec()
     }
 
-    /// Dequantize the Q4_0 data to a full-precision `Tensor<Wgpu, 2>`.
+    /// Dequantize the quantized data to a full-precision `Tensor<Wgpu, 2>`.
     ///
     /// This reads the raw bytes back from GPU and dequantizes on CPU.
     /// Intended for diagnostics and testing — the hot path uses
@@ -108,19 +163,37 @@ impl Q4Tensor {
         let num_elements = n * k;
         let mut output = vec![0.0f32; num_elements];
 
-        for block_idx in 0..self.num_blocks {
-            let offset = block_idx * 18;
-            let d_bits = u16::from_le_bytes([raw[offset], raw[offset + 1]]);
-            let d = half::f16::from_bits(d_bits).to_f32();
+        match self.dtype {
+            GgmlDtype::Q4_0 => {
+                for block_idx in 0..self.num_blocks {
+                    let offset = block_idx * Q4_BLOCK_BYTES;
+                    let d_bits = u16::from_le_bytes([raw[offset], raw[offset + 1]]);
+                    let d = half::f16::from_bits(d_bits).to_f32();
 
-            let base = block_idx * 32;
-            for i in 0..16 {
-                let byte = raw[offset + 2 + i];
-                let lo = (byte & 0x0F) as f32 - 8.0;
-                let hi = ((byte >> 4) & 0x0F) as f32 - 8.0;
-                output[base + i] = lo * d;
-                output[base + i + 16] = hi * d;
+                    let base = block_idx * Q4_BLOCK_SIZE;
+                    for i in 0..16 {
+                        let byte = raw[offset + 2 + i];
+                        let lo = (byte & 0x0F) as f32 - 8.0;
+                        let hi = ((byte >> 4) & 0x0F) as f32 - 8.0;
+                        output[base + i] = lo * d;
+                        output[base + i + 16] = hi * d;
+                    }
+                }
             }
+            GgmlDtype::Q8_0 => {
+                for block_idx in 0..self.num_blocks {
+                    let offset = block_idx * Q8_BLOCK_BYTES;
+                    let d_bits = u16::from_le_bytes([raw[offset], raw[offset + 1]]);
+                    let d = half::f16::from_bits(d_bits).to_f32();
+
+                    let base = block_idx * Q8_BLOCK_SIZE;
+                    for i in 0..Q8_BLOCK_SIZE {
+                        let val = raw[offset + 2 + i] as i8;
+                        output[base + i] = d * val as f32;
+                    }
+                }
+            }
+            _ => unreachable!("Q4Tensor should only hold Q4_0 or Q8_0"),
         }
 
         let tensor_data = TensorData::new(output, [n, k]);

--- a/src/gguf/tests.rs
+++ b/src/gguf/tests.rs
@@ -1,7 +1,7 @@
-//! Unit tests for Q4_0 quantization pipeline.
+//! Unit tests for the Q4_0/Q8_0 quantization pipeline.
 //!
-//! Tests cover: GGUF parsing, Q4_0 block dequantization, and GPU q4_matmul
-//! at various shapes including real model dimensions.
+//! Tests cover: GGUF parsing, Q4_0/Q8_0 block dequantization, and GPU
+//! q4_matmul/q8_matmul at various shapes including real model dimensions.
 
 #[cfg(test)]
 mod tests {
@@ -691,5 +691,420 @@ mod tests {
             "Max diff {:.4e} exceeds tolerance 1e-3",
             max_diff
         );
+    }
+
+    // =========================================================================
+    // CPU-side Q8_0 helpers (test-only)
+    // =========================================================================
+
+    const Q8_BLOCK_SIZE: usize = 32;
+    const Q8_BLOCK_BYTES: usize = 34;
+
+    /// Quantize f32 data to Q8_0 format (GGML standard).
+    /// Input length must be a multiple of 32.
+    /// Returns raw bytes: 34 bytes per block (2 f16 scale + 32 int8 values).
+    fn quantize_f32_to_q8_0(data: &[f32]) -> Vec<u8> {
+        assert_eq!(
+            data.len() % Q8_BLOCK_SIZE,
+            0,
+            "Data length {} is not a multiple of {}",
+            data.len(),
+            Q8_BLOCK_SIZE
+        );
+        let n_blocks = data.len() / Q8_BLOCK_SIZE;
+        let mut output = Vec::with_capacity(n_blocks * Q8_BLOCK_BYTES);
+
+        for block_idx in 0..n_blocks {
+            let block = &data[block_idx * Q8_BLOCK_SIZE..(block_idx + 1) * Q8_BLOCK_SIZE];
+
+            // Find absmax to compute scale
+            let amax = block.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+            let d = amax / 127.0;
+            let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+
+            // Write scale as f16 (2 bytes LE)
+            let d_f16 = half::f16::from_f32(d);
+            output.extend_from_slice(&d_f16.to_le_bytes());
+
+            // Write 32 signed 8-bit values
+            for &v in block {
+                let q = (v * id).round().clamp(-127.0, 127.0) as i8;
+                output.push(q as u8);
+            }
+        }
+        output
+    }
+
+    /// Dequantize Q8_0 bytes back to f32.
+    fn dequantize_q8_0_to_f32(q8_bytes: &[u8], n_elements: usize) -> Vec<f32> {
+        assert_eq!(
+            n_elements % Q8_BLOCK_SIZE,
+            0,
+            "Element count {} is not a multiple of {}",
+            n_elements,
+            Q8_BLOCK_SIZE
+        );
+        let n_blocks = n_elements / Q8_BLOCK_SIZE;
+        assert_eq!(q8_bytes.len(), n_blocks * Q8_BLOCK_BYTES);
+        let mut output = vec![0.0f32; n_elements];
+
+        for block_idx in 0..n_blocks {
+            let offset = block_idx * Q8_BLOCK_BYTES;
+            let d_bits = u16::from_le_bytes([q8_bytes[offset], q8_bytes[offset + 1]]);
+            let d = half::f16::from_bits(d_bits).to_f32();
+
+            let base = block_idx * Q8_BLOCK_SIZE;
+            for i in 0..Q8_BLOCK_SIZE {
+                let val = q8_bytes[offset + 2 + i] as i8;
+                output[base + i] = d * val as f32;
+            }
+        }
+        output
+    }
+
+    /// Build a minimal GGUF v3 file in memory with one Q8_0 tensor.
+    fn build_minimal_gguf_q8(tensor_name: &str, shape: &[u64], q8_data: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Header
+        buf.extend_from_slice(&0x46554747u32.to_le_bytes()); // magic "GGUF"
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&1u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&1u64.to_le_bytes()); // metadata_kv_count
+
+        // Metadata KV: general.architecture = "voxtral"
+        write_gguf_string(&mut buf, "general.architecture");
+        buf.extend_from_slice(&8u32.to_le_bytes()); // value type: STRING
+        write_gguf_string(&mut buf, "voxtral");
+
+        // Tensor info
+        write_gguf_string(&mut buf, tensor_name);
+        buf.extend_from_slice(&(shape.len() as u32).to_le_bytes()); // n_dimensions
+        for &dim in shape {
+            buf.extend_from_slice(&dim.to_le_bytes());
+        }
+        buf.extend_from_slice(&8u32.to_le_bytes()); // dtype: Q8_0
+        buf.extend_from_slice(&0u64.to_le_bytes()); // offset (relative to data start)
+
+        // Alignment padding to 32 bytes
+        let alignment = 32;
+        let padding = (alignment - (buf.len() % alignment)) % alignment;
+        buf.extend(std::iter::repeat_n(0u8, padding));
+
+        // Tensor data
+        buf.extend_from_slice(q8_data);
+
+        buf
+    }
+
+    // =========================================================================
+    // Q8_0 block-level dequantization tests (CPU-only, no GPU needed)
+    // =========================================================================
+
+    #[test]
+    fn test_q8_block_dequant() {
+        // 32 values spanning [-1, 1]
+        let original: Vec<f32> = (0..32).map(|i| (i as f32 - 15.5) / 15.5).collect();
+
+        let q8_bytes = quantize_f32_to_q8_0(&original);
+        assert_eq!(q8_bytes.len(), Q8_BLOCK_BYTES, "One Q8_0 block = 34 bytes");
+
+        // Verify scale
+        let d_bits = u16::from_le_bytes([q8_bytes[0], q8_bytes[1]]);
+        let d = half::f16::from_bits(d_bits).to_f32();
+        let expected_d = original.iter().map(|v| v.abs()).fold(0.0f32, f32::max) / 127.0;
+        assert!(
+            (d - expected_d).abs() < 0.001,
+            "Scale mismatch: got {}, expected {}",
+            d,
+            expected_d
+        );
+
+        // Dequantize and compare — Q8 half-step is d/2 ≈ 0.004 for [-1, 1] data
+        let dequantized = dequantize_q8_0_to_f32(&q8_bytes, 32);
+        assert_eq!(dequantized.len(), 32);
+
+        let mut max_diff: f32 = 0.0;
+        for (a, b) in dequantized.iter().zip(original.iter()) {
+            max_diff = max_diff.max((a - b).abs());
+        }
+        println!(
+            "Q8 block dequant max diff: {:.4e} (scale d={:.6})",
+            max_diff, d
+        );
+        assert!(
+            max_diff < 0.005,
+            "Max diff {:.4e} exceeds tolerance 0.005",
+            max_diff
+        );
+    }
+
+    #[test]
+    fn test_q8_block_edge_cases() {
+        // All zeros
+        let zeros = vec![0.0f32; 32];
+        let q8_zeros = quantize_f32_to_q8_0(&zeros);
+        let deq_zeros = dequantize_q8_0_to_f32(&q8_zeros, 32);
+        for (i, v) in deq_zeros.iter().enumerate() {
+            assert_eq!(*v, 0.0, "Zero block element {} should be 0.0, got {}", i, v);
+        }
+
+        // All same value
+        let uniform = vec![0.5f32; 32];
+        let q8_uniform = quantize_f32_to_q8_0(&uniform);
+        let deq_uniform = dequantize_q8_0_to_f32(&q8_uniform, 32);
+        let mut max_diff: f32 = 0.0;
+        for (a, b) in deq_uniform.iter().zip(uniform.iter()) {
+            max_diff = max_diff.max((a - b).abs());
+        }
+        assert!(
+            max_diff < 0.005,
+            "Uniform block max diff {:.4e} exceeds tolerance",
+            max_diff
+        );
+
+        // Large values — error bounded by one quantization step
+        let large: Vec<f32> = (0..32).map(|i| (i as f32 - 15.5) * 100.0).collect();
+        let q8_large = quantize_f32_to_q8_0(&large);
+        let deq_large = dequantize_q8_0_to_f32(&q8_large, 32);
+        let d_large = large.iter().map(|v| v.abs()).fold(0.0f32, f32::max) / 127.0;
+        let mut max_diff: f32 = 0.0;
+        for (a, b) in deq_large.iter().zip(large.iter()) {
+            max_diff = max_diff.max((a - b).abs());
+        }
+        assert!(
+            max_diff < d_large,
+            "Large block max diff {:.4e} exceeds one step {:.4e}",
+            max_diff,
+            d_large
+        );
+    }
+
+    // =========================================================================
+    // GGUF reader Q8_0 dtype test
+    // =========================================================================
+
+    #[test]
+    fn test_gguf_reader_q8_dtype() {
+        // Create a 32x64 Q8_0 tensor
+        let n_elements = 32 * 64;
+        let original: Vec<f32> = (0..n_elements)
+            .map(|i| ((i as f32) * 0.001 - 1.0).sin())
+            .collect();
+        let q8_data = quantize_f32_to_q8_0(&original);
+
+        let gguf_bytes = build_minimal_gguf_q8("test.weight", &[32, 64], &q8_data);
+
+        let mut reader = GgufReader::from_bytes(&gguf_bytes).expect("Failed to parse GGUF");
+
+        assert_eq!(reader.version(), 3);
+        assert_eq!(reader.tensor_count(), 1);
+
+        let tensor_info = reader.tensor_info("test.weight").expect("Tensor not found");
+        assert_eq!(tensor_info.shape(), &[32, 64]);
+        assert_eq!(tensor_info.dtype(), GgmlDtype::Q8_0);
+
+        let raw = reader.tensor_data("test.weight").expect("Data not found");
+        assert_eq!(raw.len(), q8_data.len());
+        assert_eq!(raw, q8_data.as_slice());
+    }
+
+    // =========================================================================
+    // Q8 GPU dequantization test
+    // =========================================================================
+
+    #[test]
+    fn test_q8_dequantize_gpu() {
+        let device = Default::default();
+
+        let rows = 16;
+        let cols = 16;
+        let n_elements = rows * cols;
+        let original: Vec<f32> = (0..n_elements)
+            .map(|i| ((i as f32) * 0.05 - 6.4).sin() * 0.3)
+            .collect();
+
+        let q8_bytes = quantize_f32_to_q8_0(&original);
+        let expected = dequantize_q8_0_to_f32(&q8_bytes, n_elements);
+
+        let q8_tensor = Q4Tensor::from_q8_bytes(&q8_bytes, [rows, cols], &device)
+            .expect("Failed to create Q8 tensor");
+        let dequantized = q8_tensor.dequantize();
+
+        assert_eq!(dequantized.dims(), [rows, cols]);
+
+        let deq_data = dequantized.to_data();
+        let deq_slice = deq_data.as_slice::<f32>().unwrap();
+
+        let mut max_diff: f32 = 0.0;
+        for (a, b) in deq_slice.iter().zip(expected.iter()) {
+            max_diff = max_diff.max((a - b).abs());
+        }
+        println!("Q8 GPU dequantize max diff: {:.4e}", max_diff);
+        assert!(
+            max_diff < 1e-5,
+            "Max diff {:.4e} exceeds tolerance 1e-5",
+            max_diff
+        );
+    }
+
+    #[test]
+    fn test_q8_byte_count_validation() {
+        let device = Default::default();
+
+        // Wrong byte count: 32x32 elements = 32 blocks = 1088 bytes, give 1087
+        let bad_bytes = vec![0u8; 1087];
+        assert!(
+            Q4Tensor::from_q8_bytes(&bad_bytes, [32, 32], &device).is_err(),
+            "Byte count mismatch should be rejected"
+        );
+
+        // Element count not divisible by 32
+        let bytes = vec![0u8; 34];
+        assert!(
+            Q4Tensor::from_q8_bytes(&bytes, [3, 11], &device).is_err(),
+            "Element count not divisible by 32 should be rejected"
+        );
+    }
+
+    // =========================================================================
+    // q8_matmul kernel tests
+    // =========================================================================
+
+    #[test]
+    fn test_q8_matmul_small() {
+        let device = Default::default();
+
+        let k = 32;
+        let n = 32;
+
+        // Known weights [N, K] = [32, 32] (out_features, in_features)
+        let weights_f32: Vec<f32> = (0..n * k).map(|i| ((i as f32) * 0.1).sin() * 0.5).collect();
+
+        let q8_bytes = quantize_f32_to_q8_0(&weights_f32);
+        let weights_deq = dequantize_q8_0_to_f32(&q8_bytes, n * k);
+
+        // Activations [1, 1, K]
+        let act_data: Vec<f32> = (0..k).map(|i| (i as f32) * 0.1).collect();
+
+        // CPU reference: [1, K] × [N, K]^T -> [1, N]
+        let expected = reference_matmul(&act_data, &weights_deq, 1, k, n);
+
+        // GPU path
+        let activations =
+            Tensor::<TestBackend, 3>::from_data(TensorData::new(act_data, [1, 1, k]), &device);
+        let q8_tensor = Q4Tensor::from_q8_bytes(&q8_bytes, [n, k], &device)
+            .expect("Failed to create Q8 tensor");
+        let output = q8_matmul(activations, &q8_tensor);
+
+        assert_eq!(output.dims(), [1, 1, n]);
+
+        let output_data = output.to_data();
+        let output_slice = output_data.as_slice::<f32>().unwrap();
+
+        let mut max_diff: f32 = 0.0;
+        for (a, b) in output_slice.iter().zip(expected.iter()) {
+            max_diff = max_diff.max((a - b).abs());
+        }
+        println!("Q8 matmul small max diff: {:.4e}", max_diff);
+        assert!(
+            max_diff < 1e-3,
+            "Max diff {:.4e} exceeds tolerance 1e-3",
+            max_diff
+        );
+    }
+
+    #[test]
+    fn test_q8_matmul_shapes() {
+        let device = Default::default();
+
+        // (batch, seq, K, N, tolerance, description)
+        // Goes through quantized_matmul to also cover the dtype dispatch.
+        let shapes: &[(usize, usize, usize, usize, f32, &str)] = &[
+            (1, 1, 128, 64, 1e-2, "small projection"),
+            (1, 10, 3072, 3072, 1e-2, "decoder attention wq"),
+            (1, 1, 3072, 9216, 1e-2, "decoder FFN w1"),
+        ];
+
+        for &(batch, seq, k, n, tol, desc) in shapes {
+            println!(
+                "Testing shape: {} [{}x{}x{}] x [{}x{}]^T",
+                desc, batch, seq, k, n, k
+            );
+
+            let act_data: Vec<f32> = (0..batch * seq * k)
+                .map(|i| ((i as f32) * 0.001).sin() * 0.1)
+                .collect();
+            // Weights in [N, K] layout (out_features, in_features)
+            let weight_data: Vec<f32> = (0..n * k)
+                .map(|i| ((i as f32) * 0.0007).cos() * 0.05)
+                .collect();
+
+            let q8_bytes = quantize_f32_to_q8_0(&weight_data);
+            let weight_deq = dequantize_q8_0_to_f32(&q8_bytes, n * k);
+
+            // Reference: Burn f32 matmul — dequantized weights are [N, K],
+            // transpose to [K, N] for standard matmul
+            let act_tensor = Tensor::<TestBackend, 3>::from_data(
+                TensorData::new(act_data, [batch, seq, k]),
+                &device,
+            );
+            let weight_deq_tensor =
+                Tensor::<TestBackend, 2>::from_data(TensorData::new(weight_deq, [n, k]), &device);
+            let expected = act_tensor
+                .clone()
+                .matmul(weight_deq_tensor.transpose().unsqueeze::<3>());
+
+            // Q8 GPU path via the dtype-dispatching entry point
+            let q8_tensor = Q4Tensor::from_q8_bytes(&q8_bytes, [n, k], &device)
+                .expect("Failed to create Q8 tensor");
+            let output = quantized_matmul(act_tensor, &q8_tensor);
+
+            assert_eq!(output.dims(), [batch, seq, n]);
+
+            let output_data = output.to_data();
+            let expected_data = expected.to_data();
+            let out_slice = output_data.as_slice::<f32>().unwrap();
+            let exp_slice = expected_data.as_slice::<f32>().unwrap();
+
+            let mut max_diff: f32 = 0.0;
+            for (a, b) in out_slice.iter().zip(exp_slice.iter()) {
+                max_diff = max_diff.max((a - b).abs());
+            }
+            println!("  Q8 matmul {} max diff: {:.4e}", desc, max_diff);
+            assert!(
+                max_diff < tol,
+                "Q8 matmul {} max diff {:.4e} exceeds tolerance {:.4e}",
+                desc,
+                max_diff,
+                tol
+            );
+        }
+    }
+
+    // =========================================================================
+    // Q8-backed linear test
+    // =========================================================================
+
+    #[test]
+    fn test_q8_linear_forward_shape() {
+        let device = Default::default();
+
+        let in_features = 128;
+        let out_features = 64;
+
+        let weight_data: Vec<f32> = (0..out_features * in_features)
+            .map(|i| ((i as f32) * 0.001).sin() * 0.1)
+            .collect();
+        let q8_bytes = quantize_f32_to_q8_0(&weight_data);
+
+        let q8_tensor = Q4Tensor::from_q8_bytes(&q8_bytes, [out_features, in_features], &device)
+            .expect("Failed to create Q8 tensor");
+        let linear = Q4Linear::new(q8_tensor, None);
+
+        let input = Tensor::<TestBackend, 3>::zeros([2, 5, in_features], &device);
+        let output = linear.forward(input);
+
+        assert_eq!(output.dims(), [2, 5, out_features]);
     }
 }

--- a/src/gguf/tts_loader.rs
+++ b/src/gguf/tts_loader.rs
@@ -25,15 +25,15 @@ use crate::tts::codec::CodecDecoder;
 use crate::tts::config::{CodecDecoderConfig, FmTransformerConfig, TtsBackboneConfig};
 
 use super::loader::{
-    dequantize_q4_0_cpu, gguf_load_f32_tensor, gguf_load_q4_linear, gguf_load_rms_norm,
-    reverse_gguf_dims,
+    dequantize_q4_0_cpu, dequantize_q8_0_cpu, gguf_load_f32_tensor, gguf_load_q4_linear,
+    gguf_load_rms_norm, reverse_gguf_dims,
 };
 use super::model::{Q4Attention, Q4FeedForward, TokEmbedStore};
 use super::reader::{GgmlDtype, GgufReader, ShardedCursor};
 use super::tensor::Q4Tensor;
 use super::tts_model::{Q4FmLayer, Q4FmTransformer, Q4TtsBackbone, Q4TtsDecoderLayer};
 
-/// All Q4 TTS model components with token embeddings still in raw Q4 form.
+/// All Q4 TTS model components with token embeddings still in raw quantized form.
 ///
 /// Used by [`Q4TtsModelLoader::load_deferred`] to allow freeing the GGUF
 /// reader's memory before dequantizing the 131K-vocab embedding table.
@@ -46,6 +46,7 @@ pub struct Q4TtsModelParts {
     pub codec: CodecDecoder<Wgpu>,
     pub tok_embed_q4_bytes: Vec<u8>,
     pub tok_embed_shape: [usize; 2],
+    pub tok_embed_dtype: GgmlDtype,
     pub config: TtsBackboneConfig,
     pub device: WgpuDevice,
 }
@@ -58,12 +59,18 @@ impl Q4TtsModelParts {
     pub fn finalize(self) -> Result<(Q4TtsBackbone, Q4FmTransformer, CodecDecoder<Wgpu>)> {
         let [vocab, d_model] = self.tok_embed_shape;
 
-        let tok_embed_q4 =
-            Q4Tensor::from_q4_bytes(&self.tok_embed_q4_bytes, [vocab, d_model], &self.device)?;
+        let tok_embed_q4 = Q4Tensor::from_quantized_bytes(
+            &self.tok_embed_q4_bytes,
+            [vocab, d_model],
+            self.tok_embed_dtype,
+            &self.device,
+        )?;
 
+        let quant_dtype = tok_embed_q4.dtype();
         let tok_embeddings = TokEmbedStore::Q4 {
             lm_head: super::linear::Q4Linear::new(tok_embed_q4, None),
             cpu_bytes: self.tok_embed_q4_bytes,
+            quant_dtype,
         };
 
         #[allow(unused_mut)]
@@ -180,7 +187,7 @@ impl<R: Read + Seek> Q4TtsModelLoader<R> {
         let fm_config = FmTransformerConfig::default();
         let codec_config = CodecDecoderConfig::default();
 
-        // Extract raw Q4 bytes for token embeddings (don't dequantize yet)
+        // Extract raw quantized bytes for token embeddings (don't dequantize yet)
         let tok_name = "mm_audio_embeddings.tok_embeddings.weight";
         let tok_info = self
             .reader
@@ -188,6 +195,7 @@ impl<R: Read + Seek> Q4TtsModelLoader<R> {
             .with_context(|| format!("Tensor '{tok_name}' not found"))?
             .clone();
         let tok_shape = reverse_gguf_dims(tok_info.shape());
+        let tok_embed_dtype = tok_info.dtype();
         let tok_embed_q4_bytes = self.reader.tensor_data(tok_name)?;
 
         info!(layers = config.n_layers, "Loading backbone layers");
@@ -213,6 +221,7 @@ impl<R: Read + Seek> Q4TtsModelLoader<R> {
             codec,
             tok_embed_q4_bytes,
             tok_embed_shape: [tok_shape[0], tok_shape[1]],
+            tok_embed_dtype,
             config,
             device: device.clone(),
         })
@@ -759,6 +768,12 @@ impl<R: Read + Seek> Q4TtsModelLoader<R> {
             GgmlDtype::Q4_0 => {
                 let bytes = self.reader.tensor_data(name)?;
                 let f32_data = dequantize_q4_0_cpu(&bytes, shape[0] * shape[1]);
+                let tensor_data = TensorData::new(f32_data, [shape[0], shape[1]]);
+                Ok(Tensor::from_data(tensor_data, device))
+            }
+            GgmlDtype::Q8_0 => {
+                let bytes = self.reader.tensor_data(name)?;
+                let f32_data = dequantize_q8_0_cpu(&bytes, shape[0] * shape[1]);
                 let tensor_data = TensorData::new(f32_data, [shape[0], shape[1]]);
                 Ok(Tensor::from_data(tensor_data, device))
             }

--- a/src/gguf/tts_model.rs
+++ b/src/gguf/tts_model.rs
@@ -137,22 +137,30 @@ impl Q4TtsBackbone {
                 let selected = embed.clone().select(0, flat_ids);
                 selected.reshape([batch, seq, self.d_model])
             }
-            TokEmbedStore::Q4 { cpu_bytes, .. } => {
-                self.embed_from_q4_bytes(cpu_bytes, ids, batch, seq)
-            }
+            TokEmbedStore::Q4 {
+                cpu_bytes,
+                quant_dtype,
+                ..
+            } => self.embed_from_quantized_bytes(cpu_bytes, *quant_dtype, ids, batch, seq),
         }
     }
 
-    /// Dequantize specific rows from CPU Q4 bytes.
-    fn embed_from_q4_bytes(
+    /// Dequantize specific rows from CPU quantized bytes (Q4_0 or Q8_0).
+    fn embed_from_quantized_bytes(
         &self,
         cpu_bytes: &[u8],
+        dtype: super::reader::GgmlDtype,
         ids: &[i32],
         batch: usize,
         seq: usize,
     ) -> Tensor<Wgpu, 3> {
         let blocks_per_row = self.d_model / 32;
-        let bytes_per_row = blocks_per_row * 18;
+        let block_bytes = match dtype {
+            super::reader::GgmlDtype::Q4_0 => 18,
+            super::reader::GgmlDtype::Q8_0 => 34,
+            _ => unreachable!("embed_from_quantized_bytes only supports Q4_0 and Q8_0"),
+        };
+        let bytes_per_row = blocks_per_row * block_bytes;
         let mut output = vec![0.0f32; ids.len() * self.d_model];
 
         for (i, &id) in ids.iter().enumerate() {
@@ -160,17 +168,39 @@ impl Q4TtsBackbone {
             let row_bytes = &cpu_bytes[row_offset..row_offset + bytes_per_row];
             let out_slice = &mut output[i * self.d_model..(i + 1) * self.d_model];
 
-            for block in 0..blocks_per_row {
-                let bo = block * 18;
-                let d =
-                    half::f16::from_bits(u16::from_le_bytes([row_bytes[bo], row_bytes[bo + 1]]))
+            match dtype {
+                super::reader::GgmlDtype::Q4_0 => {
+                    for block in 0..blocks_per_row {
+                        let bo = block * 18;
+                        let d = half::f16::from_bits(u16::from_le_bytes([
+                            row_bytes[bo],
+                            row_bytes[bo + 1],
+                        ]))
                         .to_f32();
-                let base = block * 32;
-                for j in 0..16 {
-                    let byte = row_bytes[bo + 2 + j];
-                    out_slice[base + j] = ((byte & 0x0F) as f32 - 8.0) * d;
-                    out_slice[base + j + 16] = (((byte >> 4) & 0x0F) as f32 - 8.0) * d;
+                        let base = block * 32;
+                        for j in 0..16 {
+                            let byte = row_bytes[bo + 2 + j];
+                            out_slice[base + j] = ((byte & 0x0F) as f32 - 8.0) * d;
+                            out_slice[base + j + 16] = (((byte >> 4) & 0x0F) as f32 - 8.0) * d;
+                        }
+                    }
                 }
+                super::reader::GgmlDtype::Q8_0 => {
+                    for block in 0..blocks_per_row {
+                        let bo = block * 34;
+                        let d = half::f16::from_bits(u16::from_le_bytes([
+                            row_bytes[bo],
+                            row_bytes[bo + 1],
+                        ]))
+                        .to_f32();
+                        let base = block * 32;
+                        for j in 0..32 {
+                            let val = row_bytes[bo + 2 + j] as i8;
+                            out_slice[base + j] = d * val as f32;
+                        }
+                    }
+                }
+                _ => unreachable!(),
             }
         }
 


### PR DESCRIPTION
## Summary

This PR proposes Q8_0 support alongside the existing Q4_0 GGUF inference path for Voxtral TTS. It adds kernels, loading, dispatch, quantization tooling and synthetic test coverage.

The Q8_0 block layout is 34 bytes for 32 values, compared with 18 bytes for Q4_0. This ratio describes weight-block storage only. This PR does not include a generated full-model artifact or a measured full-model size.

## Changes

- two WGSL kernels for fused Q8 dequantization and matrix multiplication, following the existing tiled and naive Q4 paths;
- `GgmlDtype::Q8_0` support in the GGUF reader;
- generalized quantized tensors and matrix-multiplication dispatch for Q4_0 and Q8_0;
- Q8 support in linear, fused QKV, gate/up, loader and TTS model paths;
- `--quant-type {q4_0,q8_0}` in `scripts/quantize_tts_gguf.py`;
- synthetic CPU, GGUF-reader, GPU-dequantization, matrix-multiplication, dispatch, linear-shape and byte-validation tests;
- Q8 kernel micro-benchmarks matching the existing Q4 shapes;
- bounded README instructions for generating a local Q8 file.

## Reproduced verification

Checks were run on 2026-07-13 against code commit `ea59224` on a MacBook Pro with Apple M1 Pro and macOS 27.0. Commit `3a3ed0b` only bounds the README claims.

- `cargo fmt --all -- --check`: exit 0;
- `cargo clippy --features "wgpu,cli,hub" -- -D warnings`: exit 0;
- `cargo test --features "wgpu,cli,hub" --no-run`: all test targets compiled;
- the non-GPU selection used by upstream CI: 63 passed, 0 failed;
- `WGPU_BACKEND=metal cargo test --features "wgpu,cli,hub" test_q8_`: 7 passed, 0 failed;
- `cargo test --features "wgpu,cli,hub" test_gguf_reader_q8_dtype`: 1 passed, 0 failed;
- largest difference reported by the focused matrix-multiplication tests: approximately `1.53e-5`, below their configured tolerance.

The public validation receipt records the exact commands, environment, outputs and limits: [Q8_0 validation receipt](https://github.com/guillaumevele/voxtral-tts-q8/blob/main/docs/Q8_VALIDATION.md).

The mirror CI also passed Format, Clippy and Test on the documented branch: [CI run 29250576649](https://github.com/guillaumevele/voxtral-tts-q8/actions/runs/29250576649).

## Limits

These checks use synthetic tensors. No model weights were downloaded. They do not prove full-model loading, generated-audio quality, peak GPU memory, latency, real-time behavior, Vulkan parity or WASM support.

The original feature commit message records RTX 4070, model-size, performance and listening observations but does not include a reproducible receipt or artifacts. This PR body does not treat those observations as verified results.

The upstream PR remains open without maintainer review or an upstream check run at the time of this update.